### PR TITLE
Update lib/sugar-web with upstream bits

### DIFF
--- a/lib/sugar-web/.gitignore
+++ b/lib/sugar-web/.gitignore
@@ -1,0 +1,2 @@
+/lib/
+/node_modules/

--- a/lib/sugar-web/Gruntfile.js
+++ b/lib/sugar-web/Gruntfile.js
@@ -1,0 +1,62 @@
+var which = require('which');
+
+module.exports = function (grunt) {
+
+    grunt.initConfig({
+        jshint: {
+            all: [
+                '*.js',
+                'activity/**/*.js',
+                'graphics/**/*.js',
+                'test/**/*.js']
+        },
+        karma: {
+            unit: {
+                configFile: 'test/karma-unit.conf.js',
+                browsers: ['Chrome'],
+                singleRun: true
+            },
+            functional: {
+                configFile: 'test/karma-functional.conf.js',
+                browsers: ['Chrome'],
+                singleRun: true
+            }
+        },
+        jsbeautifier: {
+            mode: 'VERIFY_ONLY',
+            files: [
+                '*.js',
+                'activity/**/*.js',
+                'graphics/**/*.js',
+                'test/**/*.js'],
+            options: {
+                js: {
+                    jslintHappy: true,
+                    keepArrayIndentation: true,
+                    keepFunctionIndentation: true
+                }
+            }
+        }
+    });
+
+    grunt.registerTask('test', 'run automated tests', function () {
+        if (process.env.SUGAR_DEVELOPER) {
+            var browserPath = which.sync('sugar-web-test');
+            grunt.config('karma.unit.browsers', [browserPath]);
+            grunt.config('karma.functional.browsers', [browserPath]);
+        }
+
+        grunt.task.run('karma:unit');
+
+        if (process.env.SUGAR_DEVELOPER) {
+            grunt.task.run('karma:functional');
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-karma');
+    grunt.loadNpmTasks('grunt-jsbeautifier');
+
+    grunt.registerTask('default', ['jsbeautifier', 'jshint', 'test']);
+
+};

--- a/lib/sugar-web/bus.js
+++ b/lib/sugar-web/bus.js
@@ -16,7 +16,7 @@ define(["sugar-web/env"], function (env) {
 
         env.getEnvironment(function (error, environment) {
             var port = environment.apiSocketPort;
-            var socket = new WebSocket("ws://localhost:" + port);
+            var socket = new WebSocket("ws://0.0.0.0:" + port);
 
             socket.binaryType = "arraybuffer";
 

--- a/lib/sugar-web/graphics/css/sugar-200dpi.css
+++ b/lib/sugar-web/graphics/css/sugar-200dpi.css
@@ -480,3 +480,6 @@ ul.flat-list.striped li:nth-child(odd) {
 #activity-palette .wrapper {
   width: 371px;
 }
+#activity-palette textarea {
+  resize: none;
+}

--- a/lib/sugar-web/graphics/css/sugar-96dpi.css
+++ b/lib/sugar-web/graphics/css/sugar-96dpi.css
@@ -480,3 +480,6 @@ ul.flat-list.striped li:nth-child(odd) {
 #activity-palette .wrapper {
   width: 271px;
 }
+#activity-palette textarea {
+  resize: none;
+}

--- a/lib/sugar-web/graphics/css/sugar.less
+++ b/lib/sugar-web/graphics/css/sugar.less
@@ -618,3 +618,7 @@ ul.flat-list.striped li:nth-child(odd) {
 #activity-palette .wrapper {
   width: 5 * @cell-size - 2 * @line-width;
 }
+
+#activity-palette textarea {
+  resize: none;
+}

--- a/lib/sugar-web/package.json
+++ b/lib/sugar-web/package.json
@@ -1,4 +1,19 @@
 {
+  "name": "sugar-web",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "0.4.4",
+    "grunt-contrib-jshint": "0.10.0",
+    "karma": "0.12.14",
+    "grunt-karma": "0.8.3",
+    "karma-jasmine": "0.1.5",
+    "requirejs": "2.1.11",
+    "karma-requirejs": "0.2.1",
+    "karma-chrome-launcher": "0.1.3",
+    "grunt-jsbeautifier": "0.2.7",
+    "karma-script-launcher": "0.1.0",
+    "which": "1.0.5"
+  },
   "volo": {
     "baseUrl": "lib",
     "dependencies": {

--- a/lib/sugar-web/test/functional/datastoreSpec.js
+++ b/lib/sugar-web/test/functional/datastoreSpec.js
@@ -1,0 +1,253 @@
+define(["sugar-web/bus", "sugar-web/env", "sugar-web/datastore"], function (bus, env, datastore) {
+
+    'use strict';
+
+    var defaultTimeoutInterval = jasmine.getEnv().defaultTimeoutInterval;
+
+    describe("datastore object", function () {
+
+        beforeEach(function () {
+            // FIXME: due to db initialization,
+            // the very first save() call may take a while
+            jasmine.getEnv().defaultTimeoutInterval = 10000;
+            spyOn(env, 'isStandalone').andReturn(false);
+            bus.listen();
+        });
+
+        afterEach(function () {
+            jasmine.getEnv().defaultTimeoutInterval = defaultTimeoutInterval;
+            bus.close();
+        });
+
+        it("should be able to set and get metadata", function () {
+            var saved;
+            var gotMetadata;
+            var datastoreObject;
+            var objectId;
+            var testTitle = "hello";
+
+            runs(function () {
+                saved = false;
+
+                datastoreObject = new datastore.DatastoreObject();
+                datastoreObject.setMetadata({
+                    title: testTitle
+                });
+
+                datastoreObject.save(function () {
+                    saved = true;
+                    objectId = datastoreObject.objectId;
+                });
+            });
+
+            waitsFor(function () {
+                return saved;
+            }, "should have saved the object");
+
+            runs(function () {
+                gotMetadata = false;
+
+                datastoreObject = new datastore.DatastoreObject(objectId);
+                datastoreObject.getMetadata(function (error, metadata) {
+                    expect(metadata.title).toEqual(testTitle);
+                    gotMetadata = true;
+                });
+            });
+
+            waitsFor(function () {
+                return gotMetadata;
+            }, "should have got the object metadata");
+        });
+
+        it("should be able to save and load text", function () {
+            var saved;
+            var gotMetadata;
+            var datastoreObject;
+            var objectId;
+            var testText = "hello";
+
+            runs(function () {
+                saved = false;
+
+                datastoreObject = new datastore.DatastoreObject();
+                datastoreObject.setDataAsText(testText);
+
+                datastoreObject.save(function () {
+                    saved = true;
+                    objectId = datastoreObject.objectId;
+                });
+            });
+
+            waitsFor(function () {
+                return saved;
+            }, "should have saved the object");
+
+            runs(function () {
+                gotMetadata = false;
+
+                function onLoaded(error, metadata, text) {
+                    expect(text).toEqual(testText);
+                    gotMetadata = true;
+                }
+
+                datastoreObject = new datastore.DatastoreObject(objectId);
+                datastoreObject.loadAsText(onLoaded);
+            });
+
+            waitsFor(function () {
+                return gotMetadata;
+            }, "should have got the object metadata");
+        });
+
+    });
+
+    describe("datastore", function () {
+
+        beforeEach(function () {
+            // FIXME: due to db initialization,
+            // the very first save() call may take a while
+            jasmine.getEnv().defaultTimeoutInterval = 10000;
+            spyOn(env, 'isStandalone').andReturn(false);
+            bus.listen();
+        });
+
+        afterEach(function () {
+            jasmine.getEnv().defaultTimeoutInterval = defaultTimeoutInterval;
+            bus.close();
+        });
+
+        it("should be able to create an object", function () {
+            var wasCreated;
+
+            runs(function () {
+                wasCreated = false;
+
+                function onCreated(error, objectId) {
+                    expect(objectId).toEqual(jasmine.any(String));
+                    wasCreated = true;
+                }
+
+                datastore.create({}, onCreated);
+            });
+
+            waitsFor(function () {
+                return wasCreated;
+            }, "the object should be created");
+        });
+
+        it("should be able to set object metadata", function () {
+            var metadataSet;
+            var gotMetadata;
+            var objectId;
+            var testTitle = "hello";
+
+            runs(function () {
+                function onMetadataSet(error) {
+                    expect(error).toBeNull();
+                    metadataSet = true;
+                }
+
+                function onCreated(error, createdObjectId) {
+                    objectId = createdObjectId;
+
+                    var metadata = {
+                        title: testTitle
+                    };
+                    datastore.setMetadata(objectId, metadata, onMetadataSet);
+                }
+
+                metadataSet = false;
+
+                datastore.create({}, onCreated);
+            });
+
+            waitsFor(function () {
+                return metadataSet;
+            }, "metadata should be set");
+
+            runs(function () {
+                function onGotMetadata(error, metadata) {
+                    expect(metadata.title).toEqual(testTitle);
+                    gotMetadata = true;
+                }
+
+                gotMetadata = false;
+
+                datastore.getMetadata(objectId, onGotMetadata);
+            });
+
+            waitsFor(function () {
+                return gotMetadata;
+            }, "should have got object metadata");
+        });
+
+        it("should be able to get object metadata", function () {
+            var gotMetadata = false;
+            var testTitle = "hello";
+
+            runs(function () {
+                function onGotMetadata(error, metadata) {
+                    expect(metadata.title).toEqual(testTitle);
+                    gotMetadata = true;
+                }
+
+                function onCreated(error, objectId) {
+                    datastore.getMetadata(objectId, onGotMetadata);
+                }
+
+                datastore.create({
+                    title: testTitle
+                }, onCreated);
+            });
+
+            waitsFor(function () {
+                return gotMetadata;
+            }, "should have got object metadata");
+        });
+
+        it("should be able to load an object", function () {
+            var wasLoaded = false;
+            var objectId = null;
+            var inputStream = null;
+            var objectData = null;
+            var testData = new Uint8Array([1, 2, 3, 4]);
+
+            runs(function () {
+                function onStreamClose(error) {
+                    expect(objectData).toEqual(testData.buffer);
+                    wasLoaded = true;
+                }
+
+                function onStreamRead(error, data) {
+                    objectData = data;
+                }
+
+                function onLoaded(error, metadata, loadedInputStream) {
+                    inputStream = loadedInputStream;
+                    inputStream.read(8192, onStreamRead);
+                    inputStream.close(onStreamClose);
+                }
+
+                function onClosed(error) {
+                    datastore.load(objectId, onLoaded);
+                }
+
+                function onSaved(error, outputStream) {
+                    outputStream.write(testData);
+                    outputStream.close(onClosed);
+                }
+
+                function onCreated(error, createdObjectId) {
+                    objectId = createdObjectId;
+                    datastore.save(objectId, {}, onSaved);
+                }
+
+                datastore.create({}, onCreated);
+            });
+
+            waitsFor(function () {
+                return wasLoaded;
+            }, "the object should be loaded");
+        });
+    });
+});

--- a/lib/sugar-web/test/functional/envSpec.js
+++ b/lib/sugar-web/test/functional/envSpec.js
@@ -1,0 +1,97 @@
+define(["sugar-web/env"], function (env) {
+
+    'use strict';
+
+    describe("getObjectId", function () {
+
+        it("should return objectId from the sugar's environment", function () {
+            var environment = {
+                objectId: "objectId"
+            };
+            spyOn(env, "getEnvironment").andCallFake(function (callback) {
+                setTimeout(function () {
+                    callback(null, environment);
+                }, 0);
+            });
+            var expected_objectId;
+
+            runs(function () {
+                env.getObjectId(function (objectId) {
+                    expected_objectId = objectId;
+                });
+            });
+
+            waitsFor(function () {
+                return expected_objectId !== undefined;
+            }, "should return objectId");
+        });
+    });
+
+    describe("getEnvironment", function () {
+        var sugarOrig;
+
+        beforeEach(function () {
+            sugarOrig = JSON.parse(JSON.stringify(window.top.sugar));
+        });
+
+        afterEach(function () {
+            window.top.sugar = sugarOrig;
+        });
+
+        describe("in sugar mode", function () {
+
+            beforeEach(function () {
+                spyOn(env, 'isStandalone').andReturn(false);
+            });
+
+            describe("when env was already set", function () {
+
+                it("should run callback with null error and env", function () {
+                    var environment = {};
+                    window.top.sugar = {
+                        environment: environment
+                    };
+                    var callback = jasmine.createSpy();
+
+                    runs(function () {
+                        env.getEnvironment(callback);
+                    });
+
+                    waitsFor(function () {
+                        return callback.wasCalled;
+                    }, "callback should be executed");
+
+                    runs(function () {
+                        expect(callback).toHaveBeenCalledWith(
+                            null, environment);
+                    });
+                });
+            });
+
+            describe("when env was not set, yet", function () {
+
+                beforeEach(function () {
+                    window.top.sugar = undefined;
+                });
+
+                it("should set onEnvironmentSet handler", function () {
+                    var sugar;
+                    env.getEnvironment(function () {});
+                    sugar = window.top.sugar;
+                    expect(sugar.onEnvironmentSet).not.toBeUndefined();
+                });
+
+                it("should run callback on EnvironmentSet event", function () {
+                    var callback = jasmine.createSpy();
+                    var expectedEnv = "env";
+
+                    env.getEnvironment(callback);
+                    window.top.sugar.environment = expectedEnv;
+                    window.top.sugar.onEnvironmentSet();
+
+                    expect(callback).toHaveBeenCalledWith(null, expectedEnv);
+                });
+            });
+        });
+    });
+});

--- a/lib/sugar-web/test/functional/toolkitContractSpec.js
+++ b/lib/sugar-web/test/functional/toolkitContractSpec.js
@@ -1,0 +1,31 @@
+define(["sugar-web/env"], function (env) {
+
+    'use strict';
+
+    describe("Environment object", function () {
+
+        it("should have valid properties", function () {
+            //FIXME: we shouldn't stub this here.
+            //current implementation of isStandalone fails with sugar-web-test
+            spyOn(env, 'isStandalone').andReturn(false);
+
+            var expectedEnv;
+
+            runs(function () {
+                env.getEnvironment(function (error, environment) {
+                    expectedEnv = environment;
+                });
+            });
+
+            waitsFor(function () {
+                return expectedEnv !== undefined;
+            }, "should get sugar environment");
+
+            runs(function () {
+                expect(expectedEnv.bundleId).not.toBeUndefined();
+                expect(expectedEnv.activityId).not.toBeUndefined();
+                expect(expectedEnv.activityName).not.toBeUndefined();
+            });
+        });
+    });
+});

--- a/lib/sugar-web/test/karma-functional.conf.js
+++ b/lib/sugar-web/test/karma-functional.conf.js
@@ -1,0 +1,16 @@
+// Karma configuration for all the tests
+
+sharedConfig = require("./karma-shared.conf.js");
+
+module.exports = function (config) {
+    var testFiles = [
+        {
+            pattern: 'test/functional/**/*.js',
+            included: false
+        }
+    ];
+
+    sharedConfig(config);
+
+    config.files = config.files.concat(testFiles);
+};

--- a/lib/sugar-web/test/karma-shared.conf.js
+++ b/lib/sugar-web/test/karma-shared.conf.js
@@ -1,0 +1,75 @@
+// Karma configuration
+// Generated on Mon May 13 2013 10:01:17 GMT-0300 (ART)
+
+
+// list of files / patterns to load in the browser
+module.exports = function (config) {
+    config.set({
+        frameworks: ['jasmine', 'requirejs'],
+
+
+        // base path, that will be used to resolve files and exclude
+        basePath: '..',
+
+
+        files: [
+            'test/loader.js',
+            {
+                pattern: 'lib/**/*.js',
+                included: false
+            }, {
+                pattern: '*.js',
+                included: false
+            }, {
+                pattern: 'activity/**/*.js',
+                included: false
+            }, {
+                pattern: 'graphics/**/*',
+                included: false
+            }
+        ],
+
+
+        // list of files to exclude
+        exclude: [],
+
+
+        // test results reporter to use
+        // possible values: 'dots', 'progress', 'junit'
+        reporters: ['progress'],
+
+
+        // web server port
+        port: 9876,
+
+
+        // cli runner port
+        runnerPort: 9100,
+
+
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
+
+
+        // level of logging
+        // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO ||
+        // LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+
+        // enable / disable watching file and executing tests whenever any file
+        // changes
+        autoWatch: true,
+
+
+        // If browser does not capture in given timeout [ms], kill it
+        captureTimeout: 60000,
+
+
+        // Continuous Integration mode
+        // if true, it capture browsers, run tests and exit
+        singleRun: false,
+
+        preprocessors: {}
+    });
+};

--- a/lib/sugar-web/test/karma-unit.conf.js
+++ b/lib/sugar-web/test/karma-unit.conf.js
@@ -1,0 +1,16 @@
+// Karma configuration for unit tests
+
+sharedConfig = require("./karma-shared.conf.js");
+
+module.exports = function (config) {
+    var testFiles = [
+        {
+            pattern: 'test/unit/**/*.js',
+            included: false
+        }
+    ];
+
+    sharedConfig(config);
+
+    config.files = config.files.concat(testFiles);
+};

--- a/lib/sugar-web/test/loader.js
+++ b/lib/sugar-web/test/loader.js
@@ -1,0 +1,21 @@
+var tests = Object.keys(window.__karma__.files).filter(function (file) {
+    return (/Spec\.js$/).test(file);
+});
+
+requirejs.config({
+    // Karma serves files from '/base'
+    baseUrl: "/base",
+
+    paths: {
+        "sugar-web": ".",
+        "mustache": "lib/mustache",
+        "text": "lib/text",
+        "webL10n": "lib/webL10n"
+    },
+
+    // ask Require.js to load these files (all our tests)
+    deps: tests,
+
+    // start test run, once Require.js is done
+    callback: window.__karma__.start
+});

--- a/lib/sugar-web/test/unit/busSpec.js
+++ b/lib/sugar-web/test/unit/busSpec.js
@@ -1,0 +1,156 @@
+define(["sugar-web/bus"], function (bus) {
+
+    'use strict';
+
+    describe("bus requests", function () {
+        var client;
+
+        function MockClient() {
+            this.result = [];
+            this.error = null;
+        }
+
+        MockClient.prototype.send = function (data) {
+            var that = this;
+            setTimeout(function () {
+                var parsed = JSON.parse(data);
+
+                var message = {
+                    data: JSON.stringify({
+                        result: that.result,
+                        error: that.error,
+                        id: parsed.id
+                    })
+                };
+
+                that.onMessage(message);
+            }, 0);
+        };
+
+        MockClient.prototype.close = function () {};
+
+        beforeEach(function () {
+            client = new MockClient();
+            bus.listen(client);
+        });
+
+        afterEach(function () {
+            bus.close();
+            client = null;
+        });
+
+        it("should receive a response", function () {
+            var responseReceived;
+
+            runs(function () {
+                responseReceived = false;
+
+                function onResponseReceived(error, result) {
+                    expect(error).toBeNull();
+                    expect(result).toEqual(["hello"]);
+                    responseReceived = true;
+                }
+
+                client.result = ["hello"];
+
+                bus.sendMessage("hello", [], onResponseReceived);
+            });
+
+            waitsFor(function () {
+                return responseReceived;
+            }, "a response should be received");
+        });
+
+        it("should receive an error", function () {
+            var errorReceived;
+
+            runs(function () {
+                errorReceived = false;
+
+                function onResponseReceived(error, result) {
+                    expect(error).toEqual(jasmine.any(Error));
+                    expect(result).toBeNull();
+
+                    errorReceived = true;
+                }
+
+                client.result = null;
+                client.error = new Error("error");
+
+                bus.sendMessage("hello", [], onResponseReceived);
+            });
+
+            waitsFor(function () {
+                return errorReceived;
+            }, "an error should be received");
+        });
+
+    });
+
+    describe("bus notifications", function () {
+        var client;
+
+        function MockClient() {
+            this.params = null;
+        }
+
+        MockClient.prototype.send_notification = function (method, params) {
+            var that = this;
+
+            setTimeout(function () {
+                var message = {
+                    data: JSON.stringify({
+                        method: method,
+                        params: that.params
+                    })
+                };
+
+                that.onMessage(message);
+            }, 0);
+        };
+
+        MockClient.prototype.close = function () {};
+
+        beforeEach(function () {
+            client = new MockClient();
+            bus.listen(client);
+        });
+
+        afterEach(function () {
+            bus.close();
+            client = null;
+        });
+
+        it("should receive a notification", function () {
+            var notificationReceived;
+            var notificationParams;
+            var originalParams = {
+                param1: true,
+                param2: "foo"
+            };
+
+            runs(function () {
+                notificationReceived = false;
+                notificationParams = null;
+
+                function onNotificationReceived(params) {
+                    notificationReceived = true;
+                    notificationParams = params;
+                }
+
+                bus.onNotification("hey.there", onNotificationReceived);
+
+                client.params = originalParams;
+                client.send_notification("hey.there");
+            });
+
+            waitsFor(function () {
+                return notificationReceived;
+            }, "a notification should be received");
+
+            runs(function () {
+                expect(notificationParams).toEqual(originalParams);
+            });
+        });
+    });
+});

--- a/lib/sugar-web/test/unit/datastoreSpec.js
+++ b/lib/sugar-web/test/unit/datastoreSpec.js
@@ -1,0 +1,32 @@
+define(["sugar-web/env", "sugar-web/datastore"], function (env, datastore) {
+
+    'use strict';
+
+    describe("Ensure the datastore object has an objectId", function () {
+
+        // FIXME does not work in standalone mode
+        it("should have objectId", function () {
+            var objectId = "objectId";
+            spyOn(env, "getObjectId").andCallFake(function (callback) {
+                setTimeout(function () {
+                    callback(objectId);
+                }, 0);
+            });
+            var callback = jasmine.createSpy();
+
+            var datastoreObject = new datastore.DatastoreObject();
+
+            runs(function () {
+                datastoreObject.ensureObjectId(callback);
+            });
+
+            waitsFor(function () {
+                return datastoreObject.objectId !== undefined;
+            }, "should have objectId received from the environment");
+
+            runs(function () {
+                expect(callback).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/lib/sugar-web/test/unit/dictstoreSpec.js
+++ b/lib/sugar-web/test/unit/dictstoreSpec.js
@@ -1,0 +1,54 @@
+define(["sugar-web/dictstore", "sugar-web/env"], function (dictstore, env) {
+
+    'use strict';
+
+    describe("dictstore on standalone mode", function () {
+
+        beforeEach(function () {
+            spyOn(env, 'isStandalone').andReturn(true);
+        });
+
+        describe("init method", function () {
+
+            it("should execute callback", function () {
+                var callback = jasmine.createSpy();
+
+                dictstore.init(callback);
+                expect(callback).toHaveBeenCalled();
+            });
+
+            it("should maintain localStorage", function () {
+                localStorage.testKey = "test";
+
+                dictstore.init(function () {});
+                expect(localStorage.testKey).toBe("test");
+            });
+        });
+
+        describe("save method", function () {
+
+            it("should just execute the callback", function () {
+                var callbackExecuted;
+
+                localStorage.test_key = "test";
+
+                runs(function () {
+                    callbackExecuted = false;
+
+                    dictstore.save(function () {
+                        callbackExecuted = true;
+                    });
+                });
+
+                waitsFor(function () {
+                    return callbackExecuted === true;
+                }, "The callback should executed");
+
+                runs(function () {
+                    expect(localStorage.test_key).toBe("test");
+                });
+            });
+        });
+
+    });
+});

--- a/lib/sugar-web/test/unit/envSpec.js
+++ b/lib/sugar-web/test/unit/envSpec.js
@@ -1,0 +1,46 @@
+define(["sugar-web/env"], function (env) {
+
+    'use strict';
+
+    describe("standalone mode", function () {
+
+        it("should return true if in standalone mode", function () {
+            var noWebActivityURLScheme = "http:";
+            spyOn(env, 'getURLScheme').andReturn(noWebActivityURLScheme);
+
+            var isStandaloneMode = env.isStandalone();
+            expect(isStandaloneMode).toBe(true);
+        });
+
+        it("should return false if not in standalone mode", function () {
+            var webActivityURLScheme = "activity:";
+            spyOn(env, 'getURLScheme').andReturn(webActivityURLScheme);
+
+            var isStandaloneMode = env.isStandalone();
+            expect(isStandaloneMode).toBe(false);
+        });
+    });
+
+    describe("getEnvironment", function () {
+        it("should return {} in standalone mode", function () {
+            window.top.sugar = undefined;
+            spyOn(env, 'isStandalone').andReturn(true);
+            var actualEnv;
+
+            runs(function () {
+                env.getEnvironment(function (error, environment) {
+                    actualEnv = environment;
+                });
+            });
+
+            waitsFor(function () {
+                return actualEnv !== undefined;
+            }, "environment not to be undefined");
+
+            runs(function () {
+                expect(actualEnv).toEqual({});
+            });
+
+        });
+    });
+});

--- a/lib/sugar-web/test/unit/graphics/iconSpec.js
+++ b/lib/sugar-web/test/unit/graphics/iconSpec.js
@@ -1,0 +1,59 @@
+define(["sugar-web/graphics/icon"], function (icon) {
+
+    'use strict';
+
+    describe("icon", function () {
+        var wasLoaded;
+        var iconUrlResult;
+
+        it("should be able to change icon more than once", function () {
+            var elem = document.createElement('div');
+            var iconUrl;
+
+            function callback(url) {
+                iconUrlResult = url;
+                wasLoaded = true;
+            }
+
+            runs(function () {
+                wasLoaded = false;
+                iconUrl = "/base/graphics/icons/actions/dialog-ok-active.svg";
+                var iconInfo = {
+                    "uri": iconUrl,
+                    "strokeColor": '#B20008',
+                    "fillColor": '#FF2B34'
+                };
+                icon.load(iconInfo, callback);
+            });
+
+            waitsFor(function () {
+                return wasLoaded;
+            }, "icon loaded");
+
+            runs(function () {
+                expect(iconUrlResult).not.toBe(iconUrl);
+            });
+
+            runs(function () {
+                wasLoaded = false;
+                iconUrl = iconUrlResult;
+                var iconInfo = {
+                    "uri": iconUrl,
+                    "strokeColor": '#FF2B34',
+                    "fillColor": '#B20008'
+                };
+                icon.load(iconInfo, callback);
+            });
+
+            waitsFor(function () {
+                return wasLoaded;
+            }, "icon loaded");
+
+            runs(function () {
+                expect(iconUrlResult).not.toBe(iconUrl);
+            });
+
+        });
+    });
+
+});

--- a/lib/sugar-web/test/unit/graphics/menupaletteSpec.js
+++ b/lib/sugar-web/test/unit/graphics/menupaletteSpec.js
@@ -1,0 +1,78 @@
+define(["sugar-web/graphics/menupalette", "sugar-web/graphics/palette"], function (menupalette, palette) {
+
+    'use strict';
+
+    describe("menupalette", function () {
+
+        var invoker;
+        var menuData;
+        var menuPalette;
+
+        beforeEach(function () {
+            invoker = document.createElement('button');
+
+            menuData = [
+                {
+                    label: "One",
+                    id: "one-button",
+                    icon: true
+                },
+                {
+                    label: "Two",
+                    id: "two-button",
+                    icon: true
+                },
+                {
+                    label: "Three",
+                    id: "three-button",
+                    icon: true
+                }
+            ];
+
+            menuPalette = new menupalette.MenuPalette(invoker, undefined,
+                menuData);
+        });
+
+        it("should have a fixed number of clickable items", function () {
+            var buttons = menuPalette.getPalette().
+            querySelectorAll('.container button');
+            expect(buttons.length).toBe(menuData.length);
+        });
+
+        it("should emit a signal with the clicked item", function () {
+            var button;
+            var buttonSelected;
+
+            function onItemSelected(event) {
+                button = event.detail.target;
+                buttonSelected = true;
+            }
+
+            runs(function () {
+                buttonSelected = false;
+                menuPalette.addEventListener('selectItem', onItemSelected);
+
+                var buttons = menuPalette.getPalette().
+                querySelectorAll('.container button');
+                buttons[1].click();
+            });
+
+            waitsFor(function () {
+                return buttonSelected;
+            }, "should have selected a button");
+
+            runs(function () {
+                expect(button.id).toBe("two-button");
+            });
+        });
+
+        it("should be an instance of the child class", function () {
+            expect(menuPalette instanceof menupalette.MenuPalette).toBe(true);
+        });
+
+        it("should be an instance of the parent class", function () {
+            expect(menuPalette instanceof palette.Palette).toBe(true);
+        });
+
+    });
+});

--- a/lib/sugar-web/test/unit/graphics/paletteSpec.js
+++ b/lib/sugar-web/test/unit/graphics/paletteSpec.js
@@ -1,0 +1,36 @@
+define(["sugar-web/graphics/palette"], function (palette) {
+
+    'use strict';
+
+    describe("palette", function () {
+        it("should start down", function () {
+            var invoker = document.createElement('button');
+            var myPalette = new palette.Palette(invoker);
+            expect(myPalette.isDown()).toBe(true);
+        });
+
+        it("should toggle", function () {
+            var invoker = document.createElement('button');
+            var myPalette = new palette.Palette(invoker);
+            myPalette.toggle();
+            expect(myPalette.isDown()).toBe(false);
+            myPalette.toggle();
+            expect(myPalette.isDown()).toBe(true);
+        });
+
+        it("if one palette in a group popups, the others popdown", function () {
+            var invokerA = document.createElement('button');
+            var invokerB = document.createElement('button');
+            var myPaletteA = new palette.Palette(invokerA);
+            var myPaletteB = new palette.Palette(invokerB);
+            myPaletteA.toggle();
+            expect(myPaletteA.isDown()).toBe(false);
+            expect(myPaletteB.isDown()).toBe(true);
+            myPaletteB.toggle();
+            expect(myPaletteA.isDown()).toBe(true);
+            expect(myPaletteB.isDown()).toBe(false);
+        });
+
+    });
+
+});

--- a/lib/sugar-web/test/unit/graphics/radiobuttonsgroupSpec.js
+++ b/lib/sugar-web/test/unit/graphics/radiobuttonsgroupSpec.js
@@ -1,0 +1,97 @@
+define(["sugar-web/graphics/radiobuttonsgroup"], function (
+    radioButtonsGroup) {
+
+    'use strict';
+
+    var elem1;
+    var elem2;
+    var elem3;
+
+    beforeEach(function () {
+        elem1 = document.createElement('button');
+        elem2 = document.createElement('button');
+        elem3 = document.createElement('button');
+    });
+
+    describe("radioToolButton", function () {
+        var wasClicked;
+
+        it("should construct", function () {
+            var radio = new radioButtonsGroup.RadioButtonsGroup(
+            [elem1, elem2, elem3]);
+            expect(radio.elems.length).toBe(3);
+        });
+
+        it("should start active the first by default", function () {
+            var radio = new radioButtonsGroup.RadioButtonsGroup(
+            [elem1, elem2, elem3]);
+            expect(radio.getActive()).toBe(elem1);
+        });
+
+        it("should start active the first with 'active' class", function () {
+            elem2.className = "active red";
+            elem3.className = "active blue";
+            var radio = new radioButtonsGroup.RadioButtonsGroup(
+            [elem1, elem2, elem3]);
+            expect(radio.getActive()).toBe(elem2);
+        });
+
+        it("should add 'active' class to the selected item", function () {
+            var radio = new radioButtonsGroup.RadioButtonsGroup(
+            [elem1, elem2, elem3]);
+            var elem = radio.getActive();
+            expect(elem.classList.contains('active')).toBe(true);
+        });
+
+        it("should change the active one on click", function () {
+            var radio = new radioButtonsGroup.RadioButtonsGroup(
+            [elem1, elem2, elem3]);
+
+            // let's click elem2
+
+            runs(function () {
+                wasClicked = false;
+
+                elem2.onclick = function () {
+                    wasClicked = true;
+                };
+
+                elem2.click();
+            });
+
+            waitsFor(function () {
+                return wasClicked;
+            }, "the element should be clicked");
+
+            runs(function () {
+                var elem = radio.getActive();
+                expect(elem).toBe(elem2);
+                expect(elem.classList.contains('active')).toBe(true);
+            });
+
+            // now let's click elem1
+
+            runs(function () {
+                wasClicked = false;
+
+                elem1.onclick = function () {
+                    wasClicked = true;
+                };
+
+                elem1.click();
+            });
+
+            waitsFor(function () {
+                return wasClicked;
+            }, "the element should be clicked");
+
+            runs(function () {
+                var elem = radio.getActive();
+                expect(elem).toBe(elem1);
+                expect(elem.classList.contains('active')).toBe(true);
+            });
+        });
+
+    });
+
+});


### PR DESCRIPTION
Recently, we pushed into sugar-web a fix for issue of not being
able to resolve "localhost", which is to use 0.0.0.0 instead.

Therefore, it is recommended that we update web activities with
upstream sugar-web from the following commit or higher.

sugar-web commit: e17b17dc36e4dbe9d215daa8cc35169230b04149

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
