### PR TITLE
Update lib/sugar-web with upstream bits

### DIFF
--- a/lib/sugar-web/.gitignore
+++ b/lib/sugar-web/.gitignore
@@ -1,0 +1,2 @@
+/lib/
+/node_modules/

--- a/lib/sugar-web/Gruntfile.js
+++ b/lib/sugar-web/Gruntfile.js
@@ -1,0 +1,62 @@
+var which = require('which');
+
+module.exports = function (grunt) {
+
+    grunt.initConfig({
+        jshint: {
+            all: [
+                '*.js',
+                'activity/**/*.js',
+                'graphics/**/*.js',
+                'test/**/*.js']
+        },
+        karma: {
+            unit: {
+                configFile: 'test/karma-unit.conf.js',
+                browsers: ['Chrome'],
+                singleRun: true
+            },
+            functional: {
+                configFile: 'test/karma-functional.conf.js',
+                browsers: ['Chrome'],
+                singleRun: true
+            }
+        },
+        jsbeautifier: {
+            mode: 'VERIFY_ONLY',
+            files: [
+                '*.js',
+                'activity/**/*.js',
+                'graphics/**/*.js',
+                'test/**/*.js'],
+            options: {
+                js: {
+                    jslintHappy: true,
+                    keepArrayIndentation: true,
+                    keepFunctionIndentation: true
+                }
+            }
+        }
+    });
+
+    grunt.registerTask('test', 'run automated tests', function () {
+        if (process.env.SUGAR_DEVELOPER) {
+            var browserPath = which.sync('sugar-web-test');
+            grunt.config('karma.unit.browsers', [browserPath]);
+            grunt.config('karma.functional.browsers', [browserPath]);
+        }
+
+        grunt.task.run('karma:unit');
+
+        if (process.env.SUGAR_DEVELOPER) {
+            grunt.task.run('karma:functional');
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-karma');
+    grunt.loadNpmTasks('grunt-jsbeautifier');
+
+    grunt.registerTask('default', ['jsbeautifier', 'jshint', 'test']);
+
+};

--- a/lib/sugar-web/bus.js
+++ b/lib/sugar-web/bus.js
@@ -16,7 +16,7 @@ define(["sugar-web/env"], function (env) {
 
         env.getEnvironment(function (error, environment) {
             var port = environment.apiSocketPort;
-            var socket = new WebSocket("ws://localhost:" + port);
+            var socket = new WebSocket("ws://0.0.0.0:" + port);
 
             socket.binaryType = "arraybuffer";
 

--- a/lib/sugar-web/graphics/css/sugar-200dpi.css
+++ b/lib/sugar-web/graphics/css/sugar-200dpi.css
@@ -480,3 +480,6 @@ ul.flat-list.striped li:nth-child(odd) {
 #activity-palette .wrapper {
   width: 371px;
 }
+#activity-palette textarea {
+  resize: none;
+}

--- a/lib/sugar-web/graphics/css/sugar-96dpi.css
+++ b/lib/sugar-web/graphics/css/sugar-96dpi.css
@@ -480,3 +480,6 @@ ul.flat-list.striped li:nth-child(odd) {
 #activity-palette .wrapper {
   width: 271px;
 }
+#activity-palette textarea {
+  resize: none;
+}

--- a/lib/sugar-web/graphics/css/sugar.less
+++ b/lib/sugar-web/graphics/css/sugar.less
@@ -618,3 +618,7 @@ ul.flat-list.striped li:nth-child(odd) {
 #activity-palette .wrapper {
   width: 5 * @cell-size - 2 * @line-width;
 }
+
+#activity-palette textarea {
+  resize: none;
+}

--- a/lib/sugar-web/package.json
+++ b/lib/sugar-web/package.json
@@ -1,4 +1,19 @@
 {
+  "name": "sugar-web",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "0.4.4",
+    "grunt-contrib-jshint": "0.10.0",
+    "karma": "0.12.14",
+    "grunt-karma": "0.8.3",
+    "karma-jasmine": "0.1.5",
+    "requirejs": "2.1.11",
+    "karma-requirejs": "0.2.1",
+    "karma-chrome-launcher": "0.1.3",
+    "grunt-jsbeautifier": "0.2.7",
+    "karma-script-launcher": "0.1.0",
+    "which": "1.0.5"
+  },
   "volo": {
     "baseUrl": "lib",
     "dependencies": {


### PR DESCRIPTION
Recently, we pushed into sugar-web a fix for issue of not being
able to resolve "localhost", which is to use 0.0.0.0 instead.

Therefore, it is recommended that we update web activities with
upstream sugar-web from the following commit or higher.

commit: e17b17dc36e4dbe9d215daa8cc35169230b04149
excluded: lib/sugar-web/test

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
